### PR TITLE
[fix] in LibAugeas::get, aug_get might set *value to NULL

### DIFF
--- a/libaugeas.cc
+++ b/libaugeas.cc
@@ -328,7 +328,11 @@ Handle<Value> LibAugeas::get(const Arguments& args)
      */
     int rc = aug_get(obj->m_aug, path, &value);
     if (1 == rc) {
+      if (value) {
         return scope.Close(String::New(value));
+      } else {
+        return scope.Close(Null());
+      }
     } else if (0 == rc) {
         return scope.Close(Undefined());
     } else if (rc < 0) {


### PR DESCRIPTION
It's possible for aug_get to set the *value to NULL. If that happens, right now you'll get a segfault, because somewhere in String::New strlen gets called on a null pointer.
